### PR TITLE
Reverse guard for bluetooth allowed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "improv-wifi-sdk",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "improv-wifi-sdk",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@material/mwc-button": "^0.21.0",

--- a/src/launch-button.ts
+++ b/src/launch-button.ts
@@ -53,9 +53,9 @@ export class LaunchButton extends HTMLElement {
 
     if (!LaunchButton.isSupported || !LaunchButton.isAllowed) {
       this.toggleAttribute("not-supported", true);
-      this.renderRoot.innerHTML = !LaunchButton.isSupported
-        ? "<slot name='unsupported'>Your browser does not support bluetooth provisioning. Use Google Chrome or Microsoft Edge.</slot>"
-        : "<slot name='not-allowed'>You can only use Improv on HTTPS sites or localhost.</slot>";
+      this.renderRoot.innerHTML = !LaunchButton.isAllowed
+        ? "<slot name='not-allowed'>You can only use Improv on HTTPS sites or localhost.</slot>"
+        : "<slot name='unsupported'>Your browser does not support bluetooth provisioning. Use Google Chrome or Microsoft Edge.</slot>";
       return;
     }
 


### PR DESCRIPTION
Warn first if web bluetooth would not be allowed because the context is not secure before checking if web bluetooth is possible.

If web bluetooth is not allowed, it will also be detected as not supported.