### PR TITLE
Updated to allow all devices and seek to provision, this is to suppor…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "Improv Wi-Fi maintainers",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "script/build"
+    "prepublishOnly": "script/build",
+    "build": "tsc && rollup -c"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",

--- a/src/provision.ts
+++ b/src/provision.ts
@@ -7,13 +7,15 @@ export const startProvisioning = async (button: LaunchButton) => {
   let device: BluetoothDevice | undefined;
   try {
     device = await navigator.bluetooth.requestDevice({
-      filters: [{ services: [IMPROV_BLE_SERVICE] }],
+      acceptAllDevices: true,
+      optionalServices: [IMPROV_BLE_SERVICE]
     });
   } catch (err) {
     console.error("Failed to get device", err);
   }
 
   if (!device) {
+    console.error("Selected device is not advertising any services");
     return;
   }
 


### PR DESCRIPTION
### Primarily:
Updated to allow all devices and seek to provision, this is to support other advertising types, not just primary general advertising.

Also, there are some BLE implementations that aren't consistent in advertising generally and this results in a correct primary service advertisement using gatt, but otherwise the device would get filtered out because of it not consistently advertising its primary service.

Also, secondarily, filtering via improv only, means someone can walk around with a laptop and attempt to connect to all improv, they get an exact list of all devices that could be exploited without credentials. It's terrible security but it is making it much easier for someone to exploit, without code.

### Secondarily
I also added a build script for developers not using docker