### PR TITLE
Fix npm publish: correct repository URL and allow manual dispatch

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -3,6 +3,7 @@ name: Node.js Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish-npm:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/launch-button.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/improv-wifi/sdk-js"
+    "url": "https://github.com/improv-wifi/sdk-ble-js"
   },
   "author": "Improv Wi-Fi maintainers",
   "license": "Apache-2.0",


### PR DESCRIPTION
The 1.4.1 release never made it to npm. The release-triggered run executed the workflow as it existed at the tag commit (`135fff0`), which still used the old classic-token publish on Node 16 — the trusted-publishing fixes from #226/#229 landed on main *after* the tag, so they have never actually run.

Two changes to get 1.4.1 out:

- Add a `workflow_dispatch` trigger so the publish can be run manually from main (re-publishing the release would just re-run the old workflow at the tag).
- Fix `repository.url` in package.json: it pointed at `improv-wifi/sdk-js`, but this repo is `improv-wifi/sdk-ble-js`. `npm publish --provenance` validates this field against the repository the workflow runs in and rejects the publish on mismatch.

After merging, publish 1.4.1 by dispatching the workflow from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)