### PR TITLE
Publish on Node 24 and drop npm self-upgrade

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -15,9 +15,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      - name: Update npm to latest
-        run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --provenance


### PR DESCRIPTION
The dispatched publish run failed at `npm install -g npm@latest`: npm 12 now requires Node >=22, but the workflow pins Node 20 (`EBADENGINE`).

Bump to Node 24 and drop the self-upgrade step entirely — Node 24's bundled npm is recent enough for trusted publishing/provenance, and this matches the working workflow in sdk-serial-js.

After merging, dispatch the workflow again to publish 1.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)